### PR TITLE
Simplify Python executable path guessing in examples

### DIFF
--- a/examples/__main__.py
+++ b/examples/__main__.py
@@ -8,17 +8,9 @@
 from __future__ import print_function
 import glob
 import os
-try:
-    import pox
-    python = pox.which_python(fullpath=False)
-    if not python:
-        python = 'python'
-    elif not pox.which(python):
-        python = pox.which_python(fullpath=False, version=True)
-except ImportError:
-    python = 'python'
 import subprocess as sp
-from sys import platform
+from sys import executable, platform
+python = executable or 'python'
 shell = platform[:3] == 'win'
 
 suite = os.path.dirname(__file__) or os.path.curdir


### PR DESCRIPTION
It seems like it should be possible to replace all the `pox`-based interpreter path guessing in `examples/__main__.py` with `sys.executable`.

It’s possible this breaks on some platform that the existing code supports, but if it works it is a lot simpler and removes an otherwise-unnecessary dependency on `pox`.

On Fedora Linux with `python-unversioned-command` not installed, `pox` does not work (it returns `python` instead of `python3`) but the approach in this PR does.