### PR TITLE
drop formal support for python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: python
 
 matrix:
     include:
-        - python: '3.7'
-          env:
-
         - python: '3.8'
           env:
 
@@ -20,9 +17,6 @@ matrix:
           env:
 
         - python: '3.12-dev'
-          env:
-
-        - python: 'pypy3.7-7.3.9'
           env:
 
         - python: 'pypy3.8-7.3.9' # at 7.3.11

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Requirements
 ------------
 ``ppft`` requires:
 
-* ``python`` (or ``pypy``), **>=3.7**
+* ``python`` (or ``pypy``), **>=3.8**
 * ``setuptools``, **>=42**
 
 Optional requirements:

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@
 import os
 import sys
 # drop support for older python
-if sys.version_info < (3, 7):
-    unsupported = 'Versions of Python before 3.7 are not supported'
+if sys.version_info < (3, 8):
+    unsupported = 'Versions of Python before 3.8 are not supported'
     raise ValueError(unsupported)
 
 # get distribution meta info
@@ -55,14 +55,13 @@ setup_kwds = dict(
         'Source Code':'https://github.com/uqfoundation/ppft',
         'Bug Tracker':'https://github.com/uqfoundation/ppft/issues',
     },
-    python_requires = '>=3.7',
+    python_requires = '>=3.8',
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,11 @@
 skip_missing_interpreters=
     True
 envlist =
-    py37
     py38
     py39
     py310
     py311
     py312
-    pypy37
     pypy38
     pypy39
     pypy310


### PR DESCRIPTION
## Summary
Drop formal support for python 3.7

## Checklist
**Release Management**
- [x] Added rationale for any breakage of backwards compatibility.